### PR TITLE
Feat/add debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ yarn*.*
 logs
 .node-persist
 node_modules
+.build
 
 # managed by open-wa
 **.data.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Bot",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "program": "${workspaceFolder}\\src\\bot\\index.ts",
+            "outFiles": [
+                "${workspaceFolder}/.build/**/*.js"
+            ],
+            "outputCapture": "std"
+        }
+    ]
+}

--- a/src/bot/commands/command-list/index.ts
+++ b/src/bot/commands/command-list/index.ts
@@ -4,16 +4,16 @@ import { CommandData } from '../protocols/command';
 
 function getFiles(subDirectory?: string): string {
   if (subDirectory) {
-    return path.join(__dirname, subDirectory, '*.ts').replace(/\\/g, '/');
+    return path.join(__dirname, subDirectory, '*.(ts|js)').replace(/\\/g, '/');
   }
 
-  return path.join(__dirname, '*.ts').replace(/\\/g, '/');
+  return path.join(__dirname, '*.(ts|js)').replace(/\\/g, '/');
 }
 
 export const getCommandList = async (): Promise<CommandData[]> => {
   const publicCommandFiles = fg
     .sync(getFiles())
-    .filter((file) => !/index.ts$/.test(file));
+    .filter((file) => !/index\..s$/.test(file));
   const moderatorCommandFiles = fg.sync(getFiles('moderator'));
   const adminCommandFiles = fg.sync(getFiles('admin'));
   const commands = [] as CommandData[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "exclude": [
+    "src/panel/**/*"
+  ],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
     "rootDirs": ["./src/bot", "./src/api"],
@@ -13,9 +16,9 @@
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    // "outDir": "./",                              /* Redirect output structure to the directory. */
+    "outDir": ".build",                              /* Redirect output structure to the directory. */
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */


### PR DESCRIPTION
## Motivação

Acho que pode ser mais convidativo para colaboradores já vir com a config de debug pelo vscode com tsc, fiz aqui na minha máquina e decidir subir como pr, o que vc acha?

## Changelog

- Adicionado configuração para sourcemap e outdit nas configs do tsc
- Adicionado ignore para diretório destino do tsc
- Adicionado suporte a execução com js pós build nos paths
- Previne que o tsconfig do root, direcionado ao bot, tente interpretar a pasta panel